### PR TITLE
Added new currency for Republic of Belarus

### DIFF
--- a/resources/data/countries.json
+++ b/resources/data/countries.json
@@ -3878,6 +3878,12 @@
                 "iso_4217_numeric": 974,
                 "iso_4217_name": "Belarussian Ruble",
                 "iso_4217_minor_unit": 0
+            },
+            "BYN": {
+                "iso_4217_code": "BYN",
+                "iso_4217_numeric": 933,
+                "iso_4217_name": "Belarussian Ruble",
+                "iso_4217_minor_unit": 2
             }
         },
         "tld": [


### PR DESCRIPTION
Information about Belarus has been updated, as currency redenomination happened.
( proof read http://www.currency-iso.org/dam/downloads/lists/list_one.xml , http://eng.belta.by/economics/view/new-iso-currency-code-for-belarusian-ruble-after-redenomination-87902-2015/ )