### PR TITLE
fix/ russian federation official name

### DIFF
--- a/resources/data/countries.json
+++ b/resources/data/countries.json
@@ -27062,7 +27062,7 @@
             "official": "Russian Federation",
             "native": {
                 "rus": {
-                    "official": "Русская Федерация",
+                    "official": "Российская Федерация",
                     "common": "Россия"
                 }
             }
@@ -27125,7 +27125,7 @@
                 "common": "Rússia"
             },
             "rus": {
-                "official": "Россия Федерация",
+                "official": "Российская Федерация",
                 "common": "Россия"
             },
             "spa": {


### PR DESCRIPTION
Changed the name of the Russian Federation according to the official.

http://www.un.org/ru/member-states/index.html#gotoР