### PR TITLE
Added type hinting for array type arguments

### DIFF
--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -42,7 +42,7 @@ class Country
      *
      * @return array
      */
-    public function find($code, $attributes = [])
+    public function find($code, array $attributes = [])
     {
         $result = $this->countries->only($code);
 
@@ -60,7 +60,7 @@ class Country
      *
      * @return array
      */
-    public function findBy($attribute, $value, $attributes = [])
+    public function findBy($attribute, $value, array $attributes = [])
     {
         $result = $this->countries->where($attribute, $value);
 
@@ -76,7 +76,7 @@ class Country
      *
      * @return \Illuminate\Support\Collection
      */
-    public function findAll($attributes = [])
+    public function findAll(array $attributes = [])
     {
         $countries = $this->countries;
 


### PR DESCRIPTION
Hi, thanks for your work man, it's awesome!

As these methods do not accept ``$attributes`` in any other type than an array, I put some type hints on them :)