### PR TITLE
Allow local phpunit.xml config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build
 /vendor
 /node_modules
+phpunit.xml
 composer.phar
 composer.lock


### PR DESCRIPTION
Since we already have the phpunit.xml.dist file we should also ignore the phpunit.xml file to allow local configuration.